### PR TITLE
Support center alignment of text and images

### DIFF
--- a/_posts/2016-08-15-style-test.md
+++ b/_posts/2016-08-15-style-test.md
@@ -14,6 +14,9 @@ Below is just about everything you'll need to style in the theme. Check the sour
 
 ---
 
+# Center Heading 1
+{: .center}
+
 # Heading 1
 
 ## Heading 2
@@ -26,6 +29,7 @@ Below is just about everything you'll need to style in the theme. Check the sour
 
 ###### Heading 6
 
+
 Lorem ipsum dolor sit amet, [test link](#) adipiscing elit. **This is strong.** Nullam dignissim convallis est. Quisque aliquam. *This is emphasized.* Donec faucibus. Nunc iaculis suscipit dui. 5<sup>3</sup> = 125. Water is H<sub>2</sub>O. Nam sit amet sem. Aliquam libero nisi, imperdiet at, tincidunt nec, gravida vehicula, nisl. <u>Underline</u>. Maecenas ornare tortor. Donec sed tellus eget `COPY filename` sapien fringilla nonummy. Mauris a ante. Suspendisse quam sem, consequat at, <del>Dinner’s at 5:00.</del> commodo vitae, feugiat in, nunc. Morbi imperdiet augue <mark>mark element</mark> quis tellus.
 
 # Images
@@ -33,6 +37,7 @@ Lorem ipsum dolor sit amet, [test link](#) adipiscing elit. **This is strong.** 
 ![Large example image](http://placehold.it/800x400 "Large example image")
 ![Medium example image](http://placehold.it/400x200 "Medium example image")
 ![Small example image](http://placehold.it/200x200 "Small example image")
+![Center example image](http://placehold.it/200x200 "Center"){: .center-image}
 
 # Blockquotes
 

--- a/_sass/_site.scss
+++ b/_sass/_site.scss
@@ -148,6 +148,9 @@ body {
     margin-bottom: 1rem;
   }
 }
+.center {
+    text-align: center;
+}
 
 /*--------------
   Post list

--- a/_sass/_site.scss
+++ b/_sass/_site.scss
@@ -151,6 +151,10 @@ body {
 .center {
     text-align: center;
 }
+.center-image {
+    margin: 0 auto;
+    display: block;
+}
 
 /*--------------
   Post list


### PR DESCRIPTION
Jekyll/Kramdown does not support center alignment of text or images, so you can only do so by [modifying the CSS](https://github.com/jekyll/jekyll/issues/3219).  This PR supports both images and text.