### PR TITLE
Update font for code block

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
   <!-- Font -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   <link href='//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSans-kr.css' rel='stylesheet' type='text/css'>
-
+  <link href="https://fonts.googleapis.com/css?family=Ubuntu+Mono" rel="stylesheet">
 
   <link rel="alternate" type="application/rss+xml" title="RSS Feed for {{ site.name }}" href="{{ site.baseurl }}/feed.xml" />
   {% seo %}

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -4,8 +4,8 @@
   Font
   -------------- */
 $base-font: 'Spoqa Han Sans', 'Source Sans Pro', Apple SD Gothic Neo, Nanum Barun Gothic, Nanum Gothic, Verdana, Arial, Dotum, sans-serif;
-$code-font: 'Ubuntu Mono', monospace;
-$code-gist-font: 'Ubuntu Mono', monospace;
+$code-font: Menlo, 'Ubuntu Mono', Monaco, 'Spoqa Han Sans', monospace;
+$code-gist-font: Menlo, 'Ubuntu Mono', Monaco, 'Spoqa Han Sans', monospace;
 
 $base-font-size: 18px;
 $base-font-size-sm: 14px;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -4,8 +4,8 @@
   Font
   -------------- */
 $base-font: 'Spoqa Han Sans', 'Source Sans Pro', Apple SD Gothic Neo, Nanum Barun Gothic, Nanum Gothic, Verdana, Arial, Dotum, sans-serif;
-$code-font: Menlo, 'Spoqa Han Sans', Monaco, monospace;
-$code-gist-font: Menlo, Monaco, "Courier New", monospace;
+$code-font: 'Ubuntu Mono', monospace;
+$code-gist-font: 'Ubuntu Mono', monospace;
 
 $base-font-size: 18px;
 $base-font-size-sm: 14px;


### PR DESCRIPTION
Original font for code 'Menlo' is not imported, hence my code block is rendered with Spoqa Han Sans, which is not a monospaced one.

I add a new monospace font from Google Font and changed the font for code to it.