### PR TITLE
Update 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,9 +1,11 @@
 ---
 layout: default
+permalink: /404.html
+title: 404 Not Found
 ---
 <header>
   <h1 class="header-small">
-    <a href="{{ site.baseurl }}">{{ site.name }}</a>
+    <a href="{{site.url}}{{site.baseurl}}">{{ site.name }}</a>
   </h1>
 </header>
 <div class="page">


### PR DESCRIPTION
Current 404 is not used Github Pages due to lack or permalink flag. Currently, Github Pages shows its default 404 page for any pages that does not exist.

I modified 404.html to be suitable for Jekyll's and Github Page's 404 guideline.