### PR TITLE
[Bugfix] Changes a:visited color from $oc-white to $oc-gray-5

### DIFF
--- a/_sass/_site.scss
+++ b/_sass/_site.scss
@@ -161,7 +161,11 @@ body {
         }
 
         a:visited {
-          background-color: $oc-white;
+          background-color: $oc-gray-5;
+        }
+
+        a:visited:hover {
+          background-color: $oc-gray-7;
         }
       }
     }


### PR DESCRIPTION
Hey there,

Thanks for this lovely theme. I think this small color adjustment will be useful for others.

Since the default background is white, the visited color for a link should be something other than white so it's readable. This PR just makes visited links a slightly lighter shade of gray than unvisited links.